### PR TITLE
feat: trust GitHub immutable OIDC subjects in the deploy role

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,17 @@ This project requires at least **Node.js version 22**.
 
 7. Deploy the GitHub OIDC Stack to enable GitHub Actions workflow permissions for AWS deployments.
 
-8. Commit and push your changes to the `main` branch to trigger the CDK deploy pipeline in GitHub.
+   Local synth resolves your repository's numeric GitHub IDs through `gh api`, so run `gh auth login` first.
+
+8. Opt the repository into immutable OIDC subject claims:
+
+   ```bash
+   gh api -X PUT repos/OWNER/REPOSITORY/actions/oidc/customization/sub -F use_default=true -F use_immutable_subject=true
+   ```
+
+   The deploy role only trusts the immutable claim, so do this after step 7. See [`src/stacks/README.md`](./src/stacks/README.md#github-immutable-oidc-subjects).
+
+9. Commit and push your changes to the `main` branch to trigger the CDK deploy pipeline in GitHub.
 
 Congratulations! You've successfully set up your project.
 

--- a/src/bin/git-helper.ts
+++ b/src/bin/git-helper.ts
@@ -1,0 +1,125 @@
+import { execFileSync, execSync } from 'node:child_process';
+
+/**
+ * Immutable GitHub repository metadata used in an Actions OIDC subject.
+ *
+ * GitHub's immutable subject claim identifies a repository by numeric ID as well as by name,
+ * so a repository that is renamed, deleted and recreated, or transferred cannot silently
+ * inherit a trust policy written for the old one.
+ */
+export interface GitHubRepositoryIdentity {
+  /** GitHub account or organization that owns the repository, for example `towardsthecloud`. */
+  readonly owner: string;
+  /** Numeric GitHub ID of the owner, as a decimal string. */
+  readonly ownerId: string;
+  /** Repository name, for example `aws-cdk-starter-kit`. */
+  readonly name: string;
+  /** Numeric GitHub ID of the repository, as a decimal string. */
+  readonly id: string;
+}
+
+/**
+ * A repository other than the one being synthesized that is allowed to assume the deployment role.
+ *
+ * The numeric ID is checked in rather than looked up, because a lookup would force every
+ * synthesizing CI job to hold a token able to read the other repository. Obtain it with
+ * `gh api repos/OWNER/NAME --jq .id`.
+ */
+export interface GitHubRepositoryReference {
+  /** Repository name under the same owner, for example `my-cdk-app`. */
+  readonly name: string;
+  /** Numeric GitHub ID of the repository, as a decimal string. */
+  readonly id: string;
+}
+
+/**
+ * These subjects land in an IAM `StringLike` condition, so an unvalidated value
+ * is a trust-boundary defect rather than a cosmetic one: an `id` of `*` would
+ * widen the policy to every repository sharing that name. Constrain each field
+ * to what GitHub can actually issue, which leaves no room for a wildcard.
+ */
+const NUMERIC_ID_PATTERN = /^[0-9]+$/;
+const REPOSITORY_NAME_PATTERN = /^[A-Za-z0-9._-]+$/;
+
+/**
+ * Builds an immutable GitHub Actions OIDC subject for a repository and workflow context.
+ *
+ * @example
+ * buildGitHubActionsOidcSubject(repository, 'environment:production');
+ * // 'repo:octo-org@123456/octo-repo@456789:environment:production'
+ *
+ * @param repository - Immutable identity of the repository to trust.
+ * @param context - Subject context after the repository segment, such as `environment:production` or `*`.
+ * @returns The immutable GitHub Actions OIDC subject claim.
+ * @throws If any identity field is malformed, or the context carries an unintended wildcard.
+ */
+export function buildGitHubActionsOidcSubject(repository: GitHubRepositoryIdentity, context: string): string {
+  for (const field of ['ownerId', 'id'] as const) {
+    if (!NUMERIC_ID_PATTERN.test(repository[field])) {
+      throw new Error(`GitHub repository identity requires a decimal ${field}, got "${repository[field]}"`);
+    }
+  }
+
+  for (const field of ['owner', 'name'] as const) {
+    if (!REPOSITORY_NAME_PATTERN.test(repository[field])) {
+      throw new Error(
+        `GitHub repository identity requires a ${field} of letters, digits, '.', '_', or '-', ` +
+          `got "${repository[field]}"`,
+      );
+    }
+  }
+
+  if (context !== '*' && /[*?]/.test(context)) {
+    throw new Error(`GitHub Actions OIDC subject context must not contain a wildcard, got "${context}"`);
+  }
+
+  return `repo:${repository.owner}@${repository.ownerId}/${repository.name}@${repository.id}:${context}`;
+}
+
+/**
+ * Resolves the immutable identity of the repository being synthesized.
+ *
+ * In GitHub Actions this reads the default `GITHUB_REPOSITORY`, `GITHUB_REPOSITORY_ID`, and
+ * `GITHUB_REPOSITORY_OWNER_ID` variables, so no workflow needs a GitHub token. Locally it reads
+ * the owner and name from the `origin` remote and fetches the numeric IDs with the GitHub CLI.
+ *
+ * @returns The immutable identity of the current repository.
+ * @throws If the `origin` remote cannot be parsed, or the GitHub CLI cannot resolve the IDs.
+ */
+export function getGitRepositoryIdentity(): GitHubRepositoryIdentity {
+  const repository = process.env.GITHUB_REPOSITORY?.split('/');
+  const id = process.env.GITHUB_REPOSITORY_ID;
+  const ownerId = process.env.GITHUB_REPOSITORY_OWNER_ID;
+
+  if (repository?.length === 2 && id && ownerId) {
+    const [owner, name] = repository;
+    return { owner, ownerId, name, id };
+  }
+
+  const remoteUrl = execSync('git config --get remote.origin.url').toString().trim();
+  const match = remoteUrl.match(/(?:git@|https:\/\/)([\w.@:]+)[/:]([\w,.,-]+)\/([\w,.,-]+?)(\.git)?$/);
+  if (!match) {
+    throw new Error('Unable to parse Git repository URL');
+  }
+
+  const [, , owner, name] = match;
+
+  try {
+    return JSON.parse(
+      execFileSync(
+        'gh',
+        [
+          'api',
+          `repos/${owner}/${name}`,
+          '--jq',
+          '{owner: .owner.login, ownerId: (.owner.id | tostring), name: .name, id: (.id | tostring)}',
+        ],
+        { encoding: 'utf8' },
+      ),
+    ) as GitHubRepositoryIdentity;
+  } catch {
+    throw new Error(
+      `Unable to resolve immutable GitHub identity for ${owner}/${name}. Install the GitHub CLI and authenticate with "gh auth login" or GH_TOKEN.`,
+    );
+  }
+}

--- a/src/constructs/github-actions-oidc-construct.ts
+++ b/src/constructs/github-actions-oidc-construct.ts
@@ -1,7 +1,11 @@
-import { execSync } from 'node:child_process';
 import * as cdk from 'aws-cdk-lib';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import { Construct } from 'constructs';
+import {
+  buildGitHubActionsOidcSubject,
+  type GitHubRepositoryReference,
+  getGitRepositoryIdentity,
+} from '../bin/git-helper';
 
 const GITHUB_DOMAIN = 'token.actions.githubusercontent.com';
 const DEFAULT_ROLE_NAME = 'GitHubActionsServiceRole';
@@ -15,14 +19,20 @@ export interface GitHubActionsOidcConstructProps {
    */
   readonly environment: string;
   /**
-   * Additional repository names, under the same GitHub owner, allowed to assume the deployment role.
+   * Additional repositories, under the same GitHub owner, allowed to assume the deployment role.
    *
-   * Provide bare repository names, for example `my-cdk-app`. The GitHub owner is resolved from
-   * the current git remote. Each repository is trusted only for workflows targeting `environment`.
+   * Each entry needs the repository name and its numeric GitHub ID, because the trust policy uses
+   * GitHub's immutable subject claim. Read the ID with `gh api repos/OWNER/NAME --jq .id`. The ID is
+   * checked in rather than resolved during synthesis: a lookup would force every synthesizing CI job
+   * to hold a token able to read the other repository. Each repository is trusted only for workflows
+   * targeting `environment`.
+   *
+   * @example
+   * additionalRepositories: [{ name: 'my-cdk-app', id: '123456789' }]
    *
    * @default - only the repository resolved from the current git remote is trusted
    */
-  readonly additionalRepositories?: string[];
+  readonly additionalRepositories?: GitHubRepositoryReference[];
   /**
    * Maximum session duration for the GitHub Actions deployment role.
    *
@@ -39,6 +49,11 @@ export interface GitHubActionsOidcConstructProps {
 
 /**
  * Creates a GitHub Actions OIDC provider and IAM deployment role for AWS CDK deployments.
+ *
+ * The role trusts GitHub's immutable subject claim, `repo:OWNER@OWNER-ID/REPOSITORY@REPOSITORY-ID:CONTEXT`,
+ * so renaming, deleting, or transferring a repository cannot hand its trust to a different one. Repositories
+ * still emitting legacy subjects must be opted into immutable subjects after this role is deployed; there is
+ * no fallback to the legacy subject form.
  */
 export class GitHubActionsOidcConstruct extends Construct {
   /** GitHub Actions OIDC identity provider trusted by the deployment role. */
@@ -50,17 +65,20 @@ export class GitHubActionsOidcConstruct extends Construct {
   constructor(scope: Construct, id: string, props: GitHubActionsOidcConstructProps) {
     super(scope, id);
 
-    const { gitOwner, gitRepoName } = getGitRepositoryDetails();
+    const repository = getGitRepositoryIdentity();
 
     this.provider = new iam.OpenIdConnectProvider(this, 'GithubProvider', {
       url: `https://${GITHUB_DOMAIN}`,
       clientIds: ['sts.amazonaws.com'],
     });
 
-    const repositories = [gitRepoName, ...(props.additionalRepositories ?? [])];
-    const subjects = repositories.map(
-      (repository) => `repo:${gitOwner}/${repository}:environment:${props.environment}`,
-    );
+    const context = `environment:${props.environment}`;
+    const subjects = [
+      buildGitHubActionsOidcSubject(repository, context),
+      ...(props.additionalRepositories ?? []).map((additional) =>
+        buildGitHubActionsOidcSubject({ ...repository, ...additional }, context),
+      ),
+    ];
     const conditions: iam.Conditions = {
       StringLike: {
         [`${GITHUB_DOMAIN}:sub`]: subjects,
@@ -78,34 +96,4 @@ export class GitHubActionsOidcConstruct extends Construct {
       roleName: props.roleName ?? process.env.GITHUB_DEPLOY_ROLE ?? DEFAULT_ROLE_NAME,
     });
   }
-}
-
-/**
- * Retrieves the Git repository details from the current repository remote.
- */
-function getGitRepositoryDetails(): { gitOwner: string; gitRepoName: string } {
-  const gitRemoteUrl = getGitRemoteUrl();
-  const { gitOwner, gitRepoName } = parseGitRemoteUrl(gitRemoteUrl);
-
-  if (!gitOwner || !gitRepoName) {
-    throw new Error('Unable to parse Git repository URL');
-  }
-
-  return { gitOwner, gitRepoName };
-}
-
-function getGitRemoteUrl(): string {
-  return execSync('git config --get remote.origin.url').toString().trim();
-}
-
-function parseGitRemoteUrl(gitRemoteUrl: string): { gitOwner: string | undefined; gitRepoName: string | undefined } {
-  const urlPattern = /(?:git@|https:\/\/)([\w.@:]+)[/:]([\w,.,-]+)\/([\w,.,-]+?)(\.git)?$/;
-  const match = gitRemoteUrl.match(urlPattern);
-
-  if (!match || match.length < 4) {
-    return { gitOwner: undefined, gitRepoName: undefined };
-  }
-
-  const [, , owner, repoName] = match;
-  return { gitOwner: owner, gitRepoName: repoName };
 }

--- a/src/stacks/README.md
+++ b/src/stacks/README.md
@@ -63,7 +63,6 @@ new s3.Bucket(this, 'MyBucket', {
 
 The `StarterStack` provides a flexible foundation for your AWS CDK project, allowing you to incrementally build and organize your infrastructure as code.
 
-
 ## FoundationStack
 
 The `FoundationStack` sets up fundamental infrastructure components for AWS deployments via GitHub Actions. It combines the functionality of the GitHubOIDCStack with additional features.
@@ -77,6 +76,42 @@ The `FoundationStack` sets up fundamental infrastructure components for AWS depl
 ### Properties
 
 - `environment`: Required. Specifies the deployment stage (e.g., `dev`, `test`, `staging`, `production`).
+- `githubActionsOidc`: Optional. Tunes the deploy role: `additionalRepositories`, `maxSessionDuration`, and `roleName`.
+
+### GitHub immutable OIDC subjects
+
+The deploy role trusts GitHub's immutable subject claim:
+
+```text
+repo:OWNER@OWNER-ID/REPOSITORY@REPOSITORY-ID:environment:ENVIRONMENT
+```
+
+The numeric IDs pin the trust to one repository. Rename it, delete and recreate it, or transfer it to another owner, and the old trust no longer matches.
+
+Your repository has to emit that claim. Opt in through the API, then check it took:
+
+```bash
+gh api -X PUT repos/OWNER/REPOSITORY/actions/oidc/customization/sub -F use_default=true -F use_immutable_subject=true
+gh api repos/OWNER/REPOSITORY/actions/oidc/customization/sub --jq .use_immutable_subject
+```
+
+Deploy the `FoundationStack` first, then flip the setting. There's no fallback to the legacy `repo:OWNER/REPOSITORY:...` subject, so a repository that still emits the old claim can't assume the role.
+
+Synthesis resolves your repository's IDs on its own. GitHub Actions passes them in `GITHUB_REPOSITORY_ID` and `GITHUB_REPOSITORY_OWNER_ID`, so no workflow needs a token. Local synth reads the `origin` remote and calls `gh api`, so run `gh auth login` once.
+
+To trust a second repository under the same owner, pass its name and numeric ID:
+
+```typescript
+new FoundationStack(app, `FoundationStack-${environment}`, {
+  env: awsEnvironment,
+  environment: environment,
+  githubActionsOidc: {
+    additionalRepositories: [{ name: 'my-cdk-app', id: '123456789' }],
+  },
+});
+```
+
+Read the ID with `gh api repos/OWNER/NAME --jq .id`. It's checked in rather than looked up during synth, because a lookup would hand every synthesizing CI job a token that can read the other repository.
 
 ### Example Usage
 

--- a/src/stacks/foundation-stack.ts
+++ b/src/stacks/foundation-stack.ts
@@ -1,6 +1,7 @@
 import * as cdk from 'aws-cdk-lib';
 import { ToolkitCleaner } from 'cloudstructs/lib/toolkit-cleaner';
 import type { Construct } from 'constructs';
+import type { GitHubRepositoryReference } from '../bin/git-helper';
 import { GitHubActionsOidcConstruct } from '../constructs';
 
 /**
@@ -8,11 +9,17 @@ import { GitHubActionsOidcConstruct } from '../constructs';
  */
 export interface FoundationStackGitHubActionsOidcProps {
   /**
-   * Additional repository names, under the same GitHub owner, allowed to assume the deployment role.
+   * Additional repositories, under the same GitHub owner, allowed to assume the deployment role.
+   *
+   * Each entry needs the repository name and its numeric GitHub ID, read with
+   * `gh api repos/OWNER/NAME --jq .id`.
+   *
+   * @example
+   * additionalRepositories: [{ name: 'my-cdk-app', id: '123456789' }]
    *
    * @default - only the repository resolved from the current git remote is trusted
    */
-  readonly additionalRepositories?: string[];
+  readonly additionalRepositories?: GitHubRepositoryReference[];
   /**
    * Maximum session duration for the GitHub Actions deployment role.
    *

--- a/test/git-helper.test.ts
+++ b/test/git-helper.test.ts
@@ -1,0 +1,98 @@
+import { execFileSync, execSync } from 'node:child_process';
+import { buildGitHubActionsOidcSubject, getGitRepositoryIdentity } from '../src/bin/git-helper';
+
+jest.mock('node:child_process', () => ({
+  execFileSync: jest.fn(),
+  execSync: jest.fn(),
+}));
+
+const mockedExecFileSync = jest.mocked(execFileSync);
+const mockedExecSync = jest.mocked(execSync);
+
+afterEach(() => {
+  delete process.env.GITHUB_REPOSITORY;
+  delete process.env.GITHUB_REPOSITORY_ID;
+  delete process.env.GITHUB_REPOSITORY_OWNER_ID;
+});
+
+test('getGitRepositoryIdentity uses GitHub Actions repository metadata without invoking gh', () => {
+  process.env.GITHUB_REPOSITORY = 'octo-org/octo-repo';
+  process.env.GITHUB_REPOSITORY_ID = '456789';
+  process.env.GITHUB_REPOSITORY_OWNER_ID = '123456';
+
+  expect(getGitRepositoryIdentity()).toEqual({
+    owner: 'octo-org',
+    ownerId: '123456',
+    name: 'octo-repo',
+    id: '456789',
+  });
+  expect(mockedExecFileSync).not.toHaveBeenCalled();
+  expect(mockedExecSync).not.toHaveBeenCalled();
+});
+
+test('getGitRepositoryIdentity resolves a normal git checkout through gh', () => {
+  mockedExecSync.mockReturnValue('git@github.com:octo-org/octo-repo.git');
+  mockedExecFileSync.mockReturnValue(
+    JSON.stringify({
+      owner: 'octo-org',
+      ownerId: '123456',
+      name: 'octo-repo',
+      id: '456789',
+    }),
+  );
+
+  expect(getGitRepositoryIdentity()).toEqual({
+    owner: 'octo-org',
+    ownerId: '123456',
+    name: 'octo-repo',
+    id: '456789',
+  });
+  expect(mockedExecFileSync).toHaveBeenCalledWith('gh', expect.arrayContaining(['api', 'repos/octo-org/octo-repo']), {
+    encoding: 'utf8',
+  });
+});
+
+test('getGitRepositoryIdentity explains how to authenticate when gh cannot resolve the identity', () => {
+  mockedExecSync.mockReturnValue('git@github.com:octo-org/octo-repo.git');
+  mockedExecFileSync.mockImplementation(() => {
+    throw new Error('gh: command not found');
+  });
+
+  expect(() => getGitRepositoryIdentity()).toThrow('gh auth login');
+});
+
+const repository = {
+  owner: 'octo-org',
+  ownerId: '123456',
+  name: 'octo-repo',
+  id: '456789',
+};
+
+test('buildGitHubActionsOidcSubject renders the immutable repository subject', () => {
+  expect(buildGitHubActionsOidcSubject(repository, 'environment:production')).toBe(
+    'repo:octo-org@123456/octo-repo@456789:environment:production',
+  );
+});
+
+// The subject lands in an IAM StringLike condition, so a wildcard that slips
+// through widens the trust policy rather than merely failing.
+test.each(['ownerId', 'id'] as const)('buildGitHubActionsOidcSubject rejects a non-decimal %s', (field) => {
+  for (const value of ['', '*', '12*', 'abc']) {
+    expect(() => buildGitHubActionsOidcSubject({ ...repository, [field]: value }, 'environment:production')).toThrow(
+      `GitHub repository identity requires a decimal ${field}`,
+    );
+  }
+});
+
+test.each(['owner', 'name'] as const)('buildGitHubActionsOidcSubject rejects a wildcard %s', (field) => {
+  for (const value of ['', '*', 'octo*', 'octo/repo']) {
+    expect(() => buildGitHubActionsOidcSubject({ ...repository, [field]: value }, 'environment:production')).toThrow(
+      `GitHub repository identity requires a ${field} of letters`,
+    );
+  }
+});
+
+test('buildGitHubActionsOidcSubject rejects a wildcard inside a context', () => {
+  expect(() => buildGitHubActionsOidcSubject(repository, 'environment:prod*')).toThrow('must not contain a wildcard');
+  expect(buildGitHubActionsOidcSubject(repository, '*')).toBe('repo:octo-org@123456/octo-repo@456789:*');
+});

--- a/test/github-actions-oidc-construct.test.ts
+++ b/test/github-actions-oidc-construct.test.ts
@@ -1,51 +1,53 @@
-import { execSync } from 'node:child_process';
 import * as cdk from 'aws-cdk-lib';
 import { Match, Template } from 'aws-cdk-lib/assertions';
 import { GitHubActionsOidcConstruct } from '../src/constructs';
 
-test('GitHubActionsOidcConstruct creates default GitHub OIDC provider and deployment role', () => {
-  const previousGithubDeployRole = process.env.GITHUB_DEPLOY_ROLE;
+// Pin the repository identity so the trust policy is asserted against known values instead of
+// whichever checkout the tests happen to run in, and so no test shells out to git or the GitHub CLI.
+const previousEnvironment = { ...process.env };
+
+beforeEach(() => {
+  process.env.GITHUB_REPOSITORY = 'octo-org/octo-repo';
+  process.env.GITHUB_REPOSITORY_ID = '456789';
+  process.env.GITHUB_REPOSITORY_OWNER_ID = '123456';
   delete process.env.GITHUB_DEPLOY_ROLE;
+});
 
-  try {
-    const stack = new cdk.Stack();
+afterEach(() => {
+  process.env = { ...previousEnvironment };
+});
 
-    new GitHubActionsOidcConstruct(stack, 'GitHubActionsOidc', {
-      environment: 'test',
-    });
+test('GitHubActionsOidcConstruct creates default GitHub OIDC provider and deployment role', () => {
+  const stack = new cdk.Stack();
 
-    const { gitOwner, gitRepoName } = getGitRepositoryDetails();
-    const template = Template.fromStack(stack);
-    template.hasResourceProperties('Custom::AWSCDKOpenIdConnectProvider', {
-      Url: 'https://token.actions.githubusercontent.com',
-      ClientIDList: ['sts.amazonaws.com'],
-    });
-    template.hasResourceProperties('AWS::IAM::Role', {
-      RoleName: 'GitHubActionsServiceRole',
-      MaxSessionDuration: 7200,
-      AssumeRolePolicyDocument: {
-        Statement: [
-          Match.objectLike({
-            Action: 'sts:AssumeRoleWithWebIdentity',
-            Condition: {
-              StringEquals: {
-                'token.actions.githubusercontent.com:aud': 'sts.amazonaws.com',
-              },
-              StringLike: {
-                'token.actions.githubusercontent.com:sub': [`repo:${gitOwner}/${gitRepoName}:environment:test`],
-              },
+  new GitHubActionsOidcConstruct(stack, 'GitHubActionsOidc', {
+    environment: 'test',
+  });
+
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('Custom::AWSCDKOpenIdConnectProvider', {
+    Url: 'https://token.actions.githubusercontent.com',
+    ClientIDList: ['sts.amazonaws.com'],
+  });
+  template.hasResourceProperties('AWS::IAM::Role', {
+    RoleName: 'GitHubActionsServiceRole',
+    MaxSessionDuration: 7200,
+    AssumeRolePolicyDocument: {
+      Statement: [
+        Match.objectLike({
+          Action: 'sts:AssumeRoleWithWebIdentity',
+          Condition: {
+            StringEquals: {
+              'token.actions.githubusercontent.com:aud': 'sts.amazonaws.com',
             },
-          }),
-        ],
-      },
-    });
-  } finally {
-    if (previousGithubDeployRole !== undefined) {
-      process.env.GITHUB_DEPLOY_ROLE = previousGithubDeployRole;
-    } else {
-      delete process.env.GITHUB_DEPLOY_ROLE;
-    }
-  }
+            StringLike: {
+              'token.actions.githubusercontent.com:sub': ['repo:octo-org@123456/octo-repo@456789:environment:test'],
+            },
+          },
+        }),
+      ],
+    },
+  });
 });
 
 test('GitHubActionsOidcConstruct allows overriding the max session duration', () => {
@@ -67,10 +69,9 @@ test('GitHubActionsOidcConstruct trusts additional repositories under the same o
 
   new GitHubActionsOidcConstruct(stack, 'GitHubActionsOidc', {
     environment: 'production',
-    additionalRepositories: ['example-cdk-app'],
+    additionalRepositories: [{ name: 'example-cdk-app', id: '987654' }],
   });
 
-  const { gitOwner, gitRepoName } = getGitRepositoryDetails();
   const template = Template.fromStack(stack);
   template.hasResourceProperties('AWS::IAM::Role', {
     AssumeRolePolicyDocument: {
@@ -80,8 +81,8 @@ test('GitHubActionsOidcConstruct trusts additional repositories under the same o
           Condition: {
             StringLike: {
               'token.actions.githubusercontent.com:sub': [
-                `repo:${gitOwner}/${gitRepoName}:environment:production`,
-                `repo:${gitOwner}/example-cdk-app:environment:production`,
+                'repo:octo-org@123456/octo-repo@456789:environment:production',
+                'repo:octo-org@123456/example-cdk-app@987654:environment:production',
               ],
             },
           },
@@ -91,14 +92,15 @@ test('GitHubActionsOidcConstruct trusts additional repositories under the same o
   });
 });
 
-function getGitRepositoryDetails(): { gitOwner: string; gitRepoName: string } {
-  const gitRemoteUrl = execSync('git config --get remote.origin.url').toString().trim();
-  const match = gitRemoteUrl.match(/(?:git@|https:\/\/)([\w.@:]+)[/:]([\w,.,-]+)\/([\w,.,-]+?)(\.git)?$/);
+// A malformed ID would otherwise reach an IAM StringLike condition and widen the trust policy.
+test('GitHubActionsOidcConstruct rejects an additional repository without a numeric ID', () => {
+  const stack = new cdk.Stack();
 
-  if (!match || match.length < 4) {
-    throw new Error('Unable to parse Git repository URL');
-  }
-
-  const [, , gitOwner, gitRepoName] = match;
-  return { gitOwner, gitRepoName };
-}
+  expect(
+    () =>
+      new GitHubActionsOidcConstruct(stack, 'GitHubActionsOidc', {
+        environment: 'production',
+        additionalRepositories: [{ name: 'example-cdk-app', id: '*' }],
+      }),
+  ).toThrow('GitHub repository identity requires a decimal id');
+});


### PR DESCRIPTION
## Summary

The GitHub Actions deploy role trusted `repo:OWNER/REPOSITORY:environment:ENV`, a subject built from names alone. Rename a repository, or delete and recreate one under the same name, and the trust follows the name instead of the repository. This moves the trust policy to GitHub's immutable subject claim:

```
repo:OWNER@OWNER-ID/REPOSITORY@REPOSITORY-ID:environment:ENVIRONMENT
```

The numeric IDs pin the trust to one repository. Both `FoundationStack` and `GitHubActionsOidcConstruct` use it.

New `src/bin/git-helper.ts` resolves the identity: in GitHub Actions from the default `GITHUB_REPOSITORY`, `GITHUB_REPOSITORY_ID`, and `GITHUB_REPOSITORY_OWNER_ID` variables, and locally from the `origin` remote plus `gh api`. No workflow needs a GitHub token.

The subject lands in an IAM `StringLike` condition, so `buildGitHubActionsOidcSubject` rejects a malformed field rather than rendering it. An `id` of `*` would otherwise widen the policy to every repository sharing that name.

### Breaking change

`additionalRepositories` takes `GitHubRepositoryReference[]` instead of `string[]`:

```ts
// before
additionalRepositories: ['my-cdk-app']

// after
additionalRepositories: [{ name: 'my-cdk-app', id: '123456789' }]
```

A bare name can't produce an immutable subject. Callers supply the ID, read with `gh api repos/OWNER/NAME --jq .id`, rather than synthesis looking it up: a lookup would hand every synthesizing CI job a token able to read the other repository. It's a compile error, so nobody hits it at deploy time.

### Cutover

A repository keeps emitting the legacy subject until it's opted in, and there's no fallback. Deploy `FoundationStack` first, then:

```bash
gh api -X PUT repos/OWNER/REPOSITORY/actions/oidc/customization/sub -F use_default=true -F use_immutable_subject=true
```

Reverse that order and GitHub issues a subject the deployed role doesn't accept.

## Diagram

```mermaid
flowchart LR
  Actions["GitHub Actions default variables"] --> Resolver["getGitRepositoryIdentity()"]
  Git["origin remote + gh api"] --> Resolver
  Resolver --> Subject["buildGitHubActionsOidcSubject()"]
  Extra["additionalRepositories: name + numeric id"] --> Subject
  Subject --> Role["GitHubActionsServiceRole trust policy"]
```

## Validation

- `pnpm exec projen build`, 3 suites / 14 tests green
- New `test/git-helper.test.ts` covers the resolver and every rejection path
- OIDC construct tests pin a fake repository identity through the environment variables, so they no longer shell out to git or read whichever checkout they run in
