### PR TITLE
feat: validate CDK apps before deployment

### DIFF
--- a/.github/workflows/cdk-deploy-production.yml
+++ b/.github/workflows/cdk-deploy-production.yml
@@ -37,7 +37,7 @@ jobs:
           aws-region: us-east-1
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      - name: Run CDK synth for the PRODUCTION environment
-        run: pnpm run production:synth
+      - name: Validate CDK for the PRODUCTION environment
+        run: pnpm run production:validate
       - name: Deploy CDK to the PRODUCTION environment on AWS account 123456789012
         run: pnpm run production:deploy:all

--- a/.github/workflows/cdk-deploy-test-branch.yml
+++ b/.github/workflows/cdk-deploy-test-branch.yml
@@ -38,7 +38,7 @@ jobs:
           aws-region: us-east-1
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      - name: Run CDK synth for the TEST environment
-        run: pnpm run test:branch:synth
+      - name: Validate CDK for the TEST environment
+        run: pnpm run test:branch:validate
       - name: Deploy CDK to the TEST environment on AWS account 987654321012
         run: pnpm run test:branch:deploy:all

--- a/.github/workflows/cdk-deploy-test.yml
+++ b/.github/workflows/cdk-deploy-test.yml
@@ -34,7 +34,7 @@ jobs:
           aws-region: us-east-1
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      - name: Run CDK synth for the TEST environment
-        run: pnpm run test:synth
+      - name: Validate CDK for the TEST environment
+        run: pnpm run test:validate
       - name: Deploy CDK to the TEST environment on AWS account 987654321012
         run: pnpm run test:deploy:all

--- a/.github/workflows/cdk-diff-pr-comment.yml
+++ b/.github/workflows/cdk-diff-pr-comment.yml
@@ -34,6 +34,8 @@ jobs:
           aws-region: us-east-1
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+      - name: Validate CDK for the PRODUCTION environment
+        run: pnpm run production:validate
       - name: CDK diff and notify PR
         run: pnpm run production:diff:all > cdk-diff-output.txt 2>&1 || true
       - name: Post CDK Diff Comment in PR

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -60,7 +60,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "2.261.0",
+      "version": "2.263.0",
       "type": "runtime"
     },
     {

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -349,6 +349,22 @@
         }
       ]
     },
+    "production:validate": {
+      "name": "production:validate",
+      "description": "Validate the stacks on the PRODUCTION account",
+      "env": {
+        "CDK_DEFAULT_ACCOUNT": "123456789012",
+        "CDK_DEFAULT_REGION": "us-east-1",
+        "ENVIRONMENT": "production",
+        "GITHUB_DEPLOY_ROLE": "GitHubActionsServiceRole"
+      },
+      "steps": [
+        {
+          "exec": "cdk --unstable=validate validate",
+          "receiveArgs": true
+        }
+      ]
+    },
     "release": {
       "name": "release",
       "description": "Prepare a release from \"main\" branch",
@@ -575,6 +591,23 @@
         }
       ]
     },
+    "test:branch:validate": {
+      "name": "test:branch:validate",
+      "description": "Validate the stacks on the TEST account",
+      "env": {
+        "CDK_DEFAULT_ACCOUNT": "987654321012",
+        "CDK_DEFAULT_REGION": "us-east-1",
+        "ENVIRONMENT": "test",
+        "GITHUB_DEPLOY_ROLE": "GitHubActionsServiceRole",
+        "GIT_BRANCH_REF": "$(echo ${GIT_BRANCH_REF:-$(git rev-parse --abbrev-ref HEAD)})"
+      },
+      "steps": [
+        {
+          "exec": "cdk --unstable=validate validate",
+          "receiveArgs": true
+        }
+      ]
+    },
     "test:deploy:all": {
       "name": "test:deploy:all",
       "description": "Deploy all stacks on the TEST account",
@@ -698,6 +731,22 @@
         }
       ]
     },
+    "test:validate": {
+      "name": "test:validate",
+      "description": "Validate the stacks on the TEST account",
+      "env": {
+        "CDK_DEFAULT_ACCOUNT": "987654321012",
+        "CDK_DEFAULT_REGION": "us-east-1",
+        "ENVIRONMENT": "test",
+        "GITHUB_DEPLOY_ROLE": "GitHubActionsServiceRole"
+      },
+      "steps": [
+        {
+          "exec": "cdk --unstable=validate validate",
+          "receiveArgs": true
+        }
+      ]
+    },
     "test:watch": {
       "name": "test:watch",
       "description": "Run jest in watch mode",
@@ -775,6 +824,16 @@
         },
         {
           "spawn": "post-upgrade"
+        }
+      ]
+    },
+    "validate": {
+      "name": "validate",
+      "description": "Validate the CDK app offline against the comprehensive default rule set",
+      "steps": [
+        {
+          "exec": "cdk --unstable=validate validate --no-online",
+          "receiveArgs": true
         }
       ]
     },

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1,4 +1,4 @@
-import { awscdk, JsonFile, TextFile, YamlFile } from 'projen';
+import { awscdk, JsonFile, TextFile } from 'projen';
 import { NodePackageManager } from 'projen/lib/javascript';
 import { IndentStyle, JsTrailingCommas, QuoteStyle, Semicolons } from 'projen/lib/javascript/biome/biome-config';
 import { createCdkDeploymentWorkflows, createCdkDiffPrWorkflow } from './src/bin/cicd-helper';
@@ -33,7 +33,7 @@ const project = new awscdk.AwsCdkTypeScriptApp({
   description: 'Create and deploy an AWS CDK app on your AWS account in less than 5 minutes using GitHub actions!',
   cdkVersionPinning: true,
   cdkCliVersion: '2.1130.0', // Find the latest CDK version here: https://www.npmjs.com/package/aws-cdk
-  cdkVersion: '2.261.0', // Find the latest CDK version here: https://www.npmjs.com/package/aws-cdk-lib
+  cdkVersion: '2.263.0', // Find the latest CDK version here: https://www.npmjs.com/package/aws-cdk-lib
   projenVersion: '0.101.11', // Find the latest projen version here: https://www.npmjs.com/package/projen
   defaultReleaseBranch: 'main',
   packageManager: NodePackageManager.PNPM,
@@ -53,6 +53,8 @@ const project = new awscdk.AwsCdkTypeScriptApp({
   deps: ['cloudstructs', 'netmask'], // Runtime dependencies of this module
   devDeps: ['@types/netmask'], // Development dependencies of this module
   context: {
+    '@aws-cdk/core:annotationsInValidationReport': true,
+    '@aws-cdk/core:validateAgainstDefaultRules': true,
     'cli-telemetry': false, // Disable AWS CDK CLI telemetry, see: https://github.com/aws/aws-cdk/issues/34892
   },
   githubOptions: {
@@ -103,6 +105,13 @@ const project = new awscdk.AwsCdkTypeScriptApp({
 project.addTask('lint', {
   description: 'Lint and auto-fix the codebase using Biome',
   exec: 'biome check --no-errors-on-unmatched --write',
+  receiveArgs: true,
+});
+
+// Run comprehensive CDK validation locally without requiring AWS credentials.
+project.addTask('validate', {
+  description: 'Validate the CDK app offline against the comprehensive default rule set',
+  exec: 'cdk --unstable=validate validate --no-online',
   receiveArgs: true,
 });
 

--- a/cdk.json
+++ b/cdk.json
@@ -1,6 +1,8 @@
 {
   "app": "npx ts-node -P tsconfig.json --prefer-ts-exts src/main.ts",
   "context": {
+    "@aws-cdk/core:annotationsInValidationReport": true,
+    "@aws-cdk/core:validateAgainstDefaultRules": true,
     "cli-telemetry": false
   },
   "output": "cdk.out",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "production:diff:stack": "projen production:diff:stack",
     "production:ls": "projen production:ls",
     "production:synth": "projen production:synth",
+    "production:validate": "projen production:validate",
     "release": "projen release",
     "synth": "projen synth",
     "synth:silent": "projen synth:silent",
@@ -40,6 +41,7 @@
     "test:branch:diff:stack": "projen test:branch:diff:stack",
     "test:branch:ls": "projen test:branch:ls",
     "test:branch:synth": "projen test:branch:synth",
+    "test:branch:validate": "projen test:branch:validate",
     "test:deploy:all": "projen test:deploy:all",
     "test:deploy:stack": "projen test:deploy:stack",
     "test:destroy:all": "projen test:destroy:all",
@@ -48,9 +50,11 @@
     "test:diff:stack": "projen test:diff:stack",
     "test:ls": "projen test:ls",
     "test:synth": "projen test:synth",
+    "test:validate": "projen test:validate",
     "test:watch": "projen test:watch",
     "unbump": "projen unbump",
     "upgrade": "projen upgrade",
+    "validate": "projen validate",
     "watch": "projen watch",
     "projen": "projen"
   },
@@ -76,7 +80,7 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.261.0",
+    "aws-cdk-lib": "2.263.0",
     "cloudstructs": "^0.13.15",
     "constructs": "^10.5.1",
     "netmask": "^2.1.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     dependencies:
       aws-cdk-lib:
-        specifier: 2.261.0
-        version: 2.261.0(constructs@10.6.0)
+        specifier: 2.263.0
+        version: 2.263.0(constructs@10.6.0)
       cloudstructs:
         specifier: ^0.13.15
-        version: 0.13.15(aws-cdk-lib@2.261.0(constructs@10.6.0))(constructs@10.6.0)
+        version: 0.13.15(aws-cdk-lib@2.263.0(constructs@10.6.0))(constructs@10.6.0)
       constructs:
         specifier: ^10.5.1
         version: 10.6.0
@@ -69,8 +69,8 @@ packages:
   '@aws-cdk/asset-node-proxy-agent-v6@2.1.2':
     resolution: {integrity: sha512-pDiuqH+qY3zM9lhhLjbKJ1tnKOHzQ2V4Wr/3qsxyKeKAkuPMI/BVGvZG1PbrikUw949cGVTfVEt4ETKKYnrj0Q==}
 
-  '@aws-cdk/cloud-assembly-schema@54.10.0':
-    resolution: {integrity: sha512-G0uTune/+jvpCf3CkPUbFBMGgRJYh4NPJuvzzBHS7kLgT7EaKX5bOYBR0+VrVr4hEoCs3YlSK8uEr6AZYSIq/Q==}
+  '@aws-cdk/cloud-assembly-schema@54.16.0':
+    resolution: {integrity: sha512-Mhwh/L1buy8r6ucxdjPqSAQB559pX1ehcfusRBpDrpoOi4vHKl/iWDjXz0p1QD6ySptlzCgqbBP8TE+EE6ew0w==}
     engines: {node: '>= 18.0.0'}
     bundledDependencies:
       - jsonschema
@@ -683,12 +683,13 @@ packages:
     resolution: {integrity: sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==}
     engines: {node: '>=0.10.0'}
 
-  aws-cdk-lib@2.261.0:
-    resolution: {integrity: sha512-e52e3Abjg0HkuRWlWwtSv5+ZiMW1rhCDdL9ff7lzWXInU8xdfLJpuoimfa0IJwjiNGyphppgg52Azx9M80OA0g==}
+  aws-cdk-lib@2.263.0:
+    resolution: {integrity: sha512-cXC9wnOr+LknMee9x0kYwofgVs8aN8eBKsbzcE90sDUtpLTgWG2Bd+9koqxBKPeIU8kig/GGBFwJ69Wr+hLKDg==}
     engines: {node: '>= 20.0.0'}
     peerDependencies:
       constructs: ^10.5.0
     bundledDependencies:
+      - '@aws/cloudformation-validate'
       - '@balena/dockerignore'
       - '@aws-cdk/cloud-assembly-api'
       - case
@@ -2108,7 +2109,7 @@ snapshots:
 
   '@aws-cdk/asset-node-proxy-agent-v6@2.1.2': {}
 
-  '@aws-cdk/cloud-assembly-schema@54.10.0': {}
+  '@aws-cdk/cloud-assembly-schema@54.16.0': {}
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -2738,11 +2739,11 @@ snapshots:
 
   arrify@1.0.1: {}
 
-  aws-cdk-lib@2.261.0(constructs@10.6.0):
+  aws-cdk-lib@2.263.0(constructs@10.6.0):
     dependencies:
       '@aws-cdk/asset-awscli-v1': 2.2.282
       '@aws-cdk/asset-node-proxy-agent-v6': 2.1.2
-      '@aws-cdk/cloud-assembly-schema': 54.10.0
+      '@aws-cdk/cloud-assembly-schema': 54.16.0
       constructs: 10.6.0
 
   aws-cdk@2.1130.0: {}
@@ -2876,9 +2877,9 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
-  cloudstructs@0.13.15(aws-cdk-lib@2.261.0(constructs@10.6.0))(constructs@10.6.0):
+  cloudstructs@0.13.15(aws-cdk-lib@2.263.0(constructs@10.6.0))(constructs@10.6.0):
     dependencies:
-      aws-cdk-lib: 2.261.0(constructs@10.6.0)
+      aws-cdk-lib: 2.263.0(constructs@10.6.0)
       constructs: 10.6.0
 
   co@4.6.0: {}

--- a/src/bin/cicd-helper.ts
+++ b/src/bin/cicd-helper.ts
@@ -64,6 +64,10 @@ export function createCdkDiffPrWorkflow(
 
   const diffSteps: github.workflows.Step[] = [
     {
+      name: `Validate CDK for the ${highestEnv.toUpperCase()} environment`,
+      run: `pnpm run ${getTaskName(highestEnv, 'validate')}`,
+    },
+    {
       name: 'CDK diff and notify PR',
       run: `pnpm run ${getTaskName(highestEnv, 'diff', { taskType: 'all' })} > cdk-diff-output.txt 2>&1 || true`,
     },
@@ -189,8 +193,8 @@ function createCdkDeploymentWorkflow(
 
   const deploymentSteps: github.workflows.Step[] = [
     {
-      name: `Run CDK synth for the ${env.toUpperCase()} environment`,
-      run: `pnpm run ${getTaskName(env, 'synth', { isBranch: deployForBranch })}`,
+      name: `Validate CDK for the ${env.toUpperCase()} environment`,
+      run: `pnpm run ${getTaskName(env, 'validate', { isBranch: deployForBranch })}`,
     },
     {
       name: `Deploy CDK to the ${env.toUpperCase()} environment on AWS account ${account}`,

--- a/src/bin/env-helper.ts
+++ b/src/bin/env-helper.ts
@@ -2,7 +2,15 @@ import type { awscdk } from 'projen';
 
 /** Represents the possible deployment environments. */
 export type Environment = 'sandbox' | 'development' | 'test' | 'staging' | 'production';
-export const SUPPORTED_CDK_ACTIONS = ['synth', 'diff', 'deploy', 'deploy:hotswap', 'destroy', 'ls'] as const;
+export const SUPPORTED_CDK_ACTIONS = [
+  'synth',
+  'validate',
+  'diff',
+  'deploy',
+  'deploy:hotswap',
+  'destroy',
+  'ls',
+] as const;
 
 /** Configuration settings for a specific environment. */
 export interface EnvironmentConfig {
@@ -44,8 +52,8 @@ export function getTaskName(
 
   let taskName = isBranch ? `${environment}:branch:${action}` : `${environment}:${action}`;
 
-  // Add task type suffix for actions that support it (not synth or ls)
-  if (taskType && action !== 'synth' && action !== 'ls') {
+  // Add task type suffix for actions that support it (not synth, validate, or ls)
+  if (taskType && action !== 'synth' && action !== 'validate' && action !== 'ls') {
     taskName += `:${taskType}`;
   }
 
@@ -53,11 +61,12 @@ export function getTaskName(
 }
 
 /**
- * Adds customized 'pnpm run' commands for executing AWS CDK actions (synth, diff, deploy, deploy:hotswap, destroy, ls)
+ * Adds customized 'pnpm run' commands for executing AWS CDK actions
+ * (synth, validate, diff, deploy, deploy:hotswap, destroy, ls)
  * for a specific environment and branch (if applicable).
  *
  * Creates different task variants:
- * - For synth/ls: Single task that operates on all stacks
+ * - For synth/validate/ls: Single task that operates on all stacks
  * - For deploy/destroy/diff/deploy:hotswap: Two variants (:all for all stacks, :stack for specific stacks)
  * - Branch deployments get "branch" in the task name when GIT_BRANCH_REF is present
  * - Hotswap deployments are only available for branch deployments (when GIT_BRANCH_REF is present)
@@ -72,6 +81,7 @@ export function addCdkActionTask(cdkProject: awscdk.AwsCdkTypeScriptApp, targetA
   const expressModeArg = useExpressMode ? ' --express' : '';
   const commandMap = {
     synth: 'cdk synth',
+    validate: 'cdk --unstable=validate validate',
     destroy: `cdk destroy${expressModeArg} --force`,
     deploy: `cdk deploy${expressModeArg} --require-approval never`,
     'deploy:hotswap': 'cdk deploy --hotswap --require-approval never',
@@ -92,11 +102,12 @@ export function addCdkActionTask(cdkProject: awscdk.AwsCdkTypeScriptApp, targetA
     const execCommand = commandMap[action];
     const baseTaskName = getTaskName(targetAccount.ENVIRONMENT, action, { isBranch });
 
-    if (action === 'synth' || action === 'ls') {
+    if (action === 'synth' || action === 'validate' || action === 'ls') {
       cdkProject.addTask(baseTaskName, {
         description: createDescription(action, 'the stacks'),
         env: targetAccount,
         exec: execCommand,
+        ...(action === 'validate' ? { receiveArgs: true } : {}),
       });
     } else {
       const actionLabel = action === 'deploy:hotswap' ? 'hotswap deploy' : action;

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -1,10 +1,14 @@
-import { App } from 'aws-cdk-lib';
+import { App, Validations } from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
 import { StarterStack } from '../src/stacks';
 
 test('Snapshot', () => {
   const app = new App();
   const stack = new StarterStack(app, 'test', {});
+  Validations.of(stack).acknowledge({
+    id: 'CloudFormation-Validate::F0001',
+    reason: 'StarterStack is intentionally empty until users add their infrastructure',
+  });
 
   const template = Template.fromStack(stack);
   expect(template.toJSON()).toMatchSnapshot();


### PR DESCRIPTION
CDK now runs its bundled CloudFormation rules during synthesis and blocks deployments when the validator finds an error. This catches configuration mistakes before a CloudFormation deployment spends time provisioning or rolling back.

The Projen config pins `aws-cdk-lib` 2.263.0, turns on validation reports, and exposes an offline `pnpm validate` task that doesn't need AWS credentials. Environment tasks use `cdk validate` with online checks, and the generated PR and deploy workflows call them before diff or deploy.

## Validation

- `pnpm validate`
- `pnpm test:validate --no-online`
- `pnpm build` (14 tests)
- Projen regeneration idempotency check
- `git diff --check`

Online validation wasn't run locally because it needs the configured AWS account credentials. GitHub Actions will run it through the existing OIDC roles.
