### PR TITLE
fix: pin GitHub Actions by major tag instead of commit SHA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.self_mutation.outputs.self_mutation_happened
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@v7
         with:
           name: repo.patch
           path: repo.patch
@@ -68,7 +68,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Download patch
         id: download_patch
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        uses: actions/download-artifact@v8
         with:
           name: repo.patch
           path: ${{ runner.temp }}

--- a/.github/workflows/cdk-deploy-production.yml
+++ b/.github/workflows/cdk-deploy-production.yml
@@ -24,6 +24,8 @@ jobs:
       - name: Checkout repository
         id: checkout_repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Setup pnpm
         id: setup_pnpm
         uses: pnpm/action-setup@v6

--- a/.github/workflows/cdk-deploy-test-branch.yml
+++ b/.github/workflows/cdk-deploy-test-branch.yml
@@ -25,6 +25,8 @@ jobs:
       - name: Checkout repository
         id: checkout_repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Setup pnpm
         id: setup_pnpm
         uses: pnpm/action-setup@v6

--- a/.github/workflows/cdk-deploy-test.yml
+++ b/.github/workflows/cdk-deploy-test.yml
@@ -21,6 +21,8 @@ jobs:
       - name: Checkout repository
         id: checkout_repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Setup pnpm
         id: setup_pnpm
         uses: pnpm/action-setup@v6

--- a/.github/workflows/cdk-destroy-test-branch.yml
+++ b/.github/workflows/cdk-destroy-test-branch.yml
@@ -22,6 +22,8 @@ jobs:
       - name: Checkout repository
         id: checkout_repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Setup pnpm
         id: setup_pnpm
         uses: pnpm/action-setup@v6

--- a/.github/workflows/cdk-diff-pr-comment.yml
+++ b/.github/workflows/cdk-diff-pr-comment.yml
@@ -20,6 +20,7 @@ jobs:
         id: checkout_repository
         uses: actions/checkout@v7
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Setup pnpm
         id: setup_pnpm

--- a/.github/workflows/cdk-validate.yml
+++ b/.github/workflows/cdk-validate.yml
@@ -14,6 +14,8 @@ jobs:
       - name: Checkout repository
         id: checkout_repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Setup pnpm
         id: setup_pnpm
         uses: pnpm/action-setup@v6

--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -20,7 +20,7 @@ jobs:
     if: (github.event_name == 'pull_request' || github.event_name == 'pull_request_target')
     steps:
       - id: validate-pr-title
-        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50
+        uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Upload artifact
         id: upload_artifact
         if: ${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@v7
         with:
           name: build-artifact
           path: dist
@@ -95,7 +95,7 @@ jobs:
           package-manager-cache: false
       - name: Download build artifacts
         id: download_build_artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        uses: actions/download-artifact@v8
         with:
           artifact-ids: ${{ needs.release.outputs.artifact_id }}
           path: dist

--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Upload patch
         id: upload_patch
         if: steps.create_patch.outputs.patch_created
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@v7
         with:
           name: repo.patch
           path: repo.patch
@@ -66,7 +66,7 @@ jobs:
           ref: main
       - name: Download patch
         id: download_patch
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        uses: actions/download-artifact@v8
         with:
           name: repo.patch
           path: ${{ runner.temp }}
@@ -80,7 +80,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
       - name: Create Pull Request
         id: create-pr
-        uses: peter-evans/create-pull-request@v8.1.1
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-

--- a/src/bin/cicd-helper.ts
+++ b/src/bin/cicd-helper.ts
@@ -362,19 +362,12 @@ function createCdkDestroyWorkflow(
  * @returns A workflow step for checking out the repository.
  */
 function getCheckoutStep(ref?: string): github.workflows.Step {
-  const step: github.workflows.Step = {
+  return {
     name: 'Checkout repository',
     uses: GITHUB_ACTIONS.checkout,
+    // No job built here pushes to git, so keep the token out of .git/config
+    with: { 'persist-credentials': false, ...(ref ? { ref } : {}) },
   };
-
-  if (ref) {
-    return {
-      ...step,
-      with: { ref },
-    };
-  }
-
-  return step;
 }
 
 /**

--- a/src/bin/cicd-helper.ts
+++ b/src/bin/cicd-helper.ts
@@ -10,6 +10,10 @@ export const GITHUB_ACTIONS = {
   setupPnpm: 'pnpm/action-setup@v6',
   configureAwsCredentials: 'aws-actions/configure-aws-credentials@v6',
   cdkDiffPrCommenter: 'towardsthecloud/aws-cdk-diff-pr-commenter@v1',
+  createPullRequest: 'peter-evans/create-pull-request@v8',
+  downloadArtifact: 'actions/download-artifact@v8',
+  semanticPullRequest: 'amannn/action-semantic-pull-request@v6',
+  uploadArtifact: 'actions/upload-artifact@v7',
 } as const;
 
 /**


### PR DESCRIPTION
## What changed

Projen 0.103 renders `actions/upload-artifact`, `actions/download-artifact` and `amannn/action-semantic-pull-request` pinned to commit SHAs, and `peter-evans/create-pull-request` to a full tag. Those four are now part of the `GITHUB_ACTIONS` map in `src/bin/cicd-helper.ts`, so the actions provider rewrites every workflow to the major tag (`@v7`, `@v8`, `@v6`, `@v8`).

## Why

Review feedback on #90: major version tags are enough for this repo, and SHA pins make the workflow diffs unreadable.

## Validation

- `pnpm exec projen` regenerates cleanly; no `@<sha>` or `@vX.Y.Z` references remain in `.github/workflows`